### PR TITLE
Menu Page Notices

### DIFF
--- a/src/includes/menu-pages/alipay-buttons.inc.php
+++ b/src/includes/menu-pages/alipay-buttons.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_alipay_buttons"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/alipay-ops.inc.php
+++ b/src/includes/menu-pages/alipay-ops.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_alipay_ops"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/authnet-forms.inc.php
+++ b/src/includes/menu-pages/authnet-forms.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_authnet_forms"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/authnet-ops.inc.php
+++ b/src/includes/menu-pages/authnet-ops.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_authnet_ops"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/ccbill-buttons.inc.php
+++ b/src/includes/menu-pages/ccbill-buttons.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_ccbill_buttons"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/ccbill-ops.inc.php
+++ b/src/includes/menu-pages/ccbill-ops.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_ccbill_ops"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/clickbank-buttons.inc.php
+++ b/src/includes/menu-pages/clickbank-buttons.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_clickbank_buttons"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/clickbank-ops.inc.php
+++ b/src/includes/menu-pages/clickbank-ops.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_clickbank_ops"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/coupon-codes.inc.php
+++ b/src/includes/menu-pages/coupon-codes.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_coupon_codes"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/google-buttons.inc.php
+++ b/src/includes/menu-pages/google-buttons.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_google_buttons"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/google-ops.inc.php
+++ b/src/includes/menu-pages/google-ops.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_google_ops"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/import-export.inc.php
+++ b/src/includes/menu-pages/import-export.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_import_export"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/info.inc.php
+++ b/src/includes/menu-pages/info.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_info"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/mms-ops.inc.php
+++ b/src/includes/menu-pages/mms-ops.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_mms_ops"))
 					{
 						echo '<div class="wrap ws-menu-page">'."\n";
 
+						echo '<div class="wp-header-end"></div>'."\n";
+
 						echo '<div class="ws-menu-page-toolbox">'."\n";
 						c_ws_plugin__s2member_menu_pages_tb::display ();
 						echo '</div>'."\n";

--- a/src/includes/menu-pages/other-gateways.inc.php
+++ b/src/includes/menu-pages/other-gateways.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_other_gateways"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/paypal-forms.inc.php
+++ b/src/includes/menu-pages/paypal-forms.inc.php
@@ -48,6 +48,8 @@ if(!class_exists("c_ws_plugin__s2member_pro_menu_page_paypal_forms"))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/stripe-forms.inc.php
+++ b/src/includes/menu-pages/stripe-forms.inc.php
@@ -48,6 +48,8 @@ if(!class_exists('c_ws_plugin__s2member_pro_menu_page_stripe_forms'))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";

--- a/src/includes/menu-pages/stripe-ops.inc.php
+++ b/src/includes/menu-pages/stripe-ops.inc.php
@@ -48,6 +48,8 @@ if(!class_exists('c_ws_plugin__s2member_pro_menu_page_stripe_ops'))
 		{
 			echo '<div class="wrap ws-menu-page">'."\n";
 
+			echo '<div class="wp-header-end"></div>'."\n";
+
 			echo '<div class="ws-menu-page-toolbox">'."\n";
 			c_ws_plugin__s2member_menu_pages_tb::display();
 			echo '</div>'."\n";


### PR DESCRIPTION
- (s2Member/s2Member Pro) **UI Fix:** All menu page notices should be given the `notice` class and the additional `notice-[type]` class instead of the older generic `updated` and `error` classes. Fixed in this release. Related to [Issue #1034](https://github.com/websharks/s2member/issues/1034)

- (s2Member/s2Member Pro) **UI Fix:** Plugins displaying Dashboard-wide notices using the older `updated` and `error` classes should be handled better to avoid displaying them below the s2Member header (on s2Member menu pages) and with non-default WordPress styles. See: [Issue #1034](https://github.com/websharks/s2member/issues/1034)