### PR TITLE
Bug fix. See: https://github.com/websharks/s2member/issues/1077

### DIFF
--- a/src/includes/classes/gateways/paypal/paypal-payflow-poll.inc.php
+++ b/src/includes/classes/gateways/paypal/paypal-payflow-poll.inc.php
@@ -128,6 +128,12 @@ if(!class_exists('c_ws_plugin__s2member_pro_paypal_payflow_poll'))
 									}
 									else if($paypal['ipn_signup_vars'] && preg_match('/(expired|suspended|canceled|terminated|deactivated)/i', $paypal['STATUS']))
 									{
+										if (strtolower($paypal['STATUS']) === 'expired'
+												&& $paypal['ipn_signup_vars']['initial'] <= 0
+												&& $paypal['ipn_signup_vars']['initial_term'] !== '0 D'
+												&& !$paypal['ipn_signup_vars']['recurring']) {
+											update_user_option($user_id, 's2member_free_trial_expired_time', time());
+										}
 										$paypal['s2member_log'][] = 'Payflow IPN via polling, processed on: '.date('D M j, Y g:i:s a T');
 
 										$paypal['s2member_log'][] = 'Payflow transaction identified as ( `SUBSCRIPTION '.strtoupper($paypal['STATUS']).'` ).';


### PR DESCRIPTION
(s2Member Pro) **Bug Fix:** Merchants using PayPal Pro (Payflow Edition) to charge a fixed non-recurring fee following an initial 100% free trial period, were seeing their member accounts EOTd after the trial ended, instead of the EOT Time being set to the end of the fixed term period. Props @patdumond, James Hall, and many others for reporting this in the forums and at GitHub. See [Issue #1077](https://github.com/websharks/s2member/issues/1077).